### PR TITLE
[!258][GITHUB] Install sacremoses before running UTs in the CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,6 +34,7 @@ jobs:
       run: |
         apt-get update && apt-get --yes install libsndfile1
         python -m pip install --upgrade pip
+        pip install sacremoses
         pip install --upgrade setuptools wheel
         git submodule update --init --recursive
         python setup.py build_ext --inplace

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,12 +34,12 @@ jobs:
       run: |
         apt-get update && apt-get --yes install libsndfile1
         python -m pip install --upgrade pip
-        pip install sacremoses
         pip install --upgrade setuptools wheel
         git submodule update --init --recursive
         python setup.py build_ext --inplace
         python -m pip install --editable .
         pip install -r speech_requirements.txt
+        pip install sacremoses
         curdir=$(pwd) && cd ..
         git clone https://github.com/facebookresearch/SimulEval.git/
         cd SimulEval


### PR DESCRIPTION
## What does this PR do?
Fixes CI failures by installing sacremoses before running unit tests, since the package is used in some of them.
